### PR TITLE
Add support for **immediately** rendering a given show

### DIFF
--- a/web/core/models.py
+++ b/web/core/models.py
@@ -27,6 +27,7 @@ class Show(models.Model):
 
 KV_DEFAULTS = {
     "immediately_show_osc": False,
+    "immediately_show_show": None,
 }
 
 

--- a/web/core/templates/index.html
+++ b/web/core/templates/index.html
@@ -13,6 +13,7 @@
     <p><b>Show #{{ forloop.counter }}</b> - Type: <b>{{ show.show_type }}</b></p>
     <p>{{ show }}</p>
     <p><a href="{% url 'delete_show' show.id %}" onclick='return confirm("Are you sure you want to delete this show?")'>delete this show!!</a></p>
+    <p><a href="{% url 'set_immediately_show_show' show.id %}">SHOW THIS SHOW NOWWWW!!!!111!!!</a></p>
     {% if not forloop.last %}
       <hr>
     {% endif %}

--- a/web/core/urls.py
+++ b/web/core/urls.py
@@ -8,6 +8,9 @@ from core.views import (
     index,
     set_immediately_show_osc,
     unset_immediately_show_osc,
+    get_immediately_show_show,
+    set_immediately_show_show,
+    unset_immediately_show_show,
 )
 
 urlpatterns = [
@@ -29,5 +32,20 @@ urlpatterns = [
         "internalapi/unset_immediately_show_osc",
         unset_immediately_show_osc,
         name="unset_immediately_show_osc",
+    ),
+    path(
+        "set_immediately_show_show/<int:show_id>",
+        set_immediately_show_show,
+        name="set_immediately_show_show",
+    ),
+    path(
+        "get_immediately_show_show",
+        get_immediately_show_show,
+        name="get_immediately_show_show",
+    ),
+    path(
+        "unset_immediately_show_show",
+        unset_immediately_show_show,
+        name="unset_immediately_show_show",
     ),
 ]

--- a/web/core/views.py
+++ b/web/core/views.py
@@ -14,9 +14,20 @@ def set_immediately_show_osc(request):
     KV.set("immediately_show_osc", True)
     return HttpResponse("ok")
 
-
 def unset_immediately_show_osc(request):
     KV.set("immediately_show_osc", False)
+    return HttpResponse("ok")
+
+def get_immediately_show_show(request):
+    return JsonResponse({"immediately_show_show": KV.get("immediately_show_show")})
+
+
+def set_immediately_show_show(request, show_id):
+    KV.set("immediately_show_show", show_id)
+    return HttpResponse("ok")
+
+def unset_immediately_show_show(request):
+    KV.set("immediately_show_show", False)
     return HttpResponse("ok")
 
 


### PR DESCRIPTION
PAIR: @chiwilliams

This adds a new obnoxious link per show that causes a given show to be displayed immediately.

It piggybacks on the existing OSC functionality for doing that, and is exactly as janky, if not slightly more. It's great

Note: If you have any ideas for a better name than "[...]_immediately_show_show", we're more than happy to change it. Also sorry.