### PR TITLE
The WASM must F L O W

### DIFF
--- a/web/core/templates/index.html
+++ b/web/core/templates/index.html
@@ -77,11 +77,11 @@
   <i>HOW TO WASM:</i>
   <pre>
     - Paste your <a href="https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format">WebAssembly Text (WAT)</a> file here
-    - implement two functions
-      - a `next_frame` function with the signature: next_frame(frame_num: u16) -> *const u8
-        - return value is a pointer to an array of 456 bytes, each bit represents a location starting at the top-left and going to the bottom-right.
-      - a `is_done` function with the signature: is_done(frame_num: u16) -> u8
-        - return value is 0 for "not done" and 1 for "yeah done"
+    - implement a `next_frame` function with the signature: next_frame(frame: u16, ptr: *mut u8) -> u8
+        - first input is the current (zero-indexed) frame
+        - second input is a pointer to the 456-byte array
+        - return value is zero if you have more frames to render, one if you're done rendering things
+          - But you only get 100 frames, don't be greedy!
     - See <a href="https://git.sr.ht/~bsprague/recurse/tree/main/item/rapidriter/simpletest">an example implementation in Rust</a>
   </pre>
 

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -146,7 +146,9 @@ def worker():
         # log.info("got shows from web service: %s", all_shows)
 
         for show in all_shows:
-            log.info("Current show: %s", show)
+            # Just too noisy for WASM
+            if show["show_type"] != "wasm":
+                log.info("Current show: %s", show)
 
             for frame in receive_frames_from_renderer(
                 show["show_type"], json_payload=show["payload"]


### PR DESCRIPTION
Fix the general brokenness of the WASM renderer:
- Give up on TypedFunction because how do computers?
- Make API smaller because one is less than two
- Less WASM YELLING IN THE WORKER WOW SO NOISY

And I tested it this time! I counted on/off bits in the output, and actually looked at the terminal logger, it Does The Things :tm: this time.

Also, your Localhost talk was beautiful and unhinged and I appreciate you.