### PR TITLE
feat: add react-router to the frontend

### DIFF
--- a/web/core/frontend/package-lock.json
+++ b/web/core/frontend/package-lock.json
@@ -13,6 +13,7 @@
                 "prismjs": "^1.30.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
+                "react-router": "^8.0.1",
                 "react-simple-code-editor": "^0.14.1",
                 "tailwindcss": "^4.1.12"
             },
@@ -2085,6 +2086,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/cookie-es": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+            "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+            "license": "MIT"
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3363,24 +3370,24 @@
             "license": "MIT"
         },
         "node_modules/react": {
-            "version": "19.0.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-            "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "19.0.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-            "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "license": "MIT",
             "dependencies": {
-                "scheduler": "^0.25.0"
+                "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.0.0"
+                "react": "^19.2.7"
             }
         },
         "node_modules/react-refresh": {
@@ -3391,6 +3398,27 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-router": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.1.tgz",
+            "integrity": "sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==",
+            "license": "MIT",
+            "dependencies": {
+                "cookie-es": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=22.22.0"
+            },
+            "peerDependencies": {
+                "react": ">=19.2.7",
+                "react-dom": ">=19.2.7"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-simple-code-editor": {
@@ -3487,9 +3515,9 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-            "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
             "license": "MIT"
         },
         "node_modules/semver": {

--- a/web/core/frontend/package-lock.json
+++ b/web/core/frontend/package-lock.json
@@ -27,6 +27,7 @@
                 "eslint-plugin-react-hooks": "^5.1.0-rc.0",
                 "eslint-plugin-react-refresh": "^0.4.9",
                 "globals": "^15.9.0",
+                "prettier": "^3.8.4",
                 "typescript": "^5.5.3",
                 "typescript-eslint": "^8.0.1",
                 "vite": "^6.0.3"
@@ -3303,6 +3304,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/prismjs": {

--- a/web/core/frontend/package.json
+++ b/web/core/frontend/package.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
+        "prettier": "^3.8.4",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^6.0.3"

--- a/web/core/frontend/package.json
+++ b/web/core/frontend/package.json
@@ -16,6 +16,7 @@
         "prismjs": "^1.30.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-router": "^8.0.1",
         "react-simple-code-editor": "^0.14.1",
         "tailwindcss": "^4.1.12"
     },

--- a/web/core/frontend/src/App.tsx
+++ b/web/core/frontend/src/App.tsx
@@ -1,10 +1,10 @@
-import Cookies from 'js-cookie';
+import Cookies from "js-cookie";
 import { useEffect, useState } from "react";
 import "./App.css";
-import { NewShowEditor } from './components/NewShowEditor';
-import { ShowCard } from './components/ShowCard';
-import { ShowEditor } from './components/ShowEditor';
-import { ShowTypeSelector } from './components/ShowTypeSelector';
+import { NewShowEditor } from "./components/NewShowEditor";
+import { ShowCard } from "./components/ShowCard";
+import { ShowEditor } from "./components/ShowEditor";
+import { ShowTypeSelector } from "./components/ShowTypeSelector";
 
 interface Show {
   id: number;
@@ -31,18 +31,18 @@ function App() {
   const [selectedShowType, setSelectedShowType] = useState<string | null>(null);
 
   const fetchShows = () => {
-    fetch('/api/shows')
-      .then(response => {
+    fetch("/api/shows")
+      .then((response) => {
         if (!response.ok) {
-          throw new Error('Failed to fetch shows');
+          throw new Error("Failed to fetch shows");
         }
         return response.json();
       })
-      .then(data => {
+      .then((data) => {
         setShows(data.shows);
         setLoading(false);
       })
-      .catch(err => {
+      .catch((err) => {
         setError(err.message);
         setLoading(false);
       });
@@ -50,91 +50,98 @@ function App() {
 
   const setShowDisabled = async (showId: number, disabled: boolean) => {
     try {
-      const response = await fetch(`/api/shows/${showId}/set_disabled?disabled=${disabled}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCsrfToken(),
+      const response = await fetch(
+        `/api/shows/${showId}/set_disabled?disabled=${disabled}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": getCsrfToken(),
+          },
         },
-      });
+      );
 
       if (!response.ok) {
-        throw new Error('Failed to update show');
+        throw new Error("Failed to update show");
       }
 
       const data = await response.json();
       if (data.success) {
-        setShows(shows.map(show => 
-          show.id === showId 
-            ? { ...show, disabled: data.disabled }
-            : show
-        ));
+        setShows(
+          shows.map((show) =>
+            show.id === showId ? { ...show, disabled: data.disabled } : show,
+          ),
+        );
       }
     } catch (err) {
-      console.error('Error updating show:', err);
+      console.error("Error updating show:", err);
     }
   };
 
   const deleteShow = async (showId: number) => {
-    if (!window.confirm('Are you sure you want to delete this show? This action cannot be undone.')) {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this show? This action cannot be undone.",
+      )
+    ) {
       return;
     }
 
     try {
       const response = await fetch(`/api/shows/${showId}/delete`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCsrfToken(),
+          "Content-Type": "application/json",
+          "X-CSRFToken": getCsrfToken(),
         },
       });
 
       if (!response.ok) {
-        throw new Error('Failed to delete show');
+        throw new Error("Failed to delete show");
       }
 
       const data = await response.json();
       if (data.success) {
-        setShows(shows.filter(show => show.id !== showId));
+        setShows(shows.filter((show) => show.id !== showId));
       }
     } catch (err) {
-      console.error('Error deleting show:', err);
+      console.error("Error deleting show:", err);
     }
   };
 
   const showImmediately = async (showId: number) => {
     try {
       const response = await fetch(`/api/shows/${showId}/show_immediately`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': getCsrfToken(),
+          "Content-Type": "application/json",
+          "X-CSRFToken": getCsrfToken(),
         },
       });
 
       if (!response.ok) {
-        throw new Error('Failed to show immediately');
+        throw new Error("Failed to show immediately");
       }
 
       const data = await response.json();
       if (!data.success) {
-        console.error('Error showing immediately:', data.message);
+        console.error("Error showing immediately:", data.message);
       }
     } catch (err) {
-      console.error('Error showing immediately:', err);
+      console.error("Error showing immediately:", err);
     }
-  }
+  };
 
   const editShow = async (showId: number) => {
     try {
       const response = await fetch(`/api/shows/${showId}`, {
         headers: {
-          'X-CSRFToken': getCsrfToken(),
+          "X-CSRFToken": getCsrfToken(),
         },
       });
 
       if (!response.ok) {
-        throw new Error('Failed to fetch show details');
+        throw new Error("Failed to fetch show details");
       }
 
       const data = await response.json();
@@ -142,7 +149,7 @@ function App() {
         setEditingShow(data.show);
       }
     } catch (err) {
-      console.error('Error fetching show details:', err);
+      console.error("Error fetching show details:", err);
     }
   };
 
@@ -173,39 +180,36 @@ function App() {
     setSelectedShowType(null);
   };
 
-
-
   const handleSaveShow = () => {
     closeEditor();
     fetchShows();
   };
 
-
   const getCsrfToken = () => {
-    return Cookies.get('csrftoken') || '';
+    return Cookies.get("csrftoken") || "";
   };
-
-
 
   useEffect(() => {
     fetchShows();
   }, []);
 
-  if (loading) return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="text-lg text-gray-600">Loading shows...</div>
-    </div>
-  );
-  
-  if (error) return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="text-lg text-red-600">Error: {error}</div>
-    </div>
-  );
+  if (loading)
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-lg text-gray-600">Loading shows...</div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-lg text-red-600">Error: {error}</div>
+      </div>
+    );
 
   if (editingShow) {
     return (
-      <ShowEditor 
+      <ShowEditor
         show={editingShow}
         onClose={closeEditor}
         onSave={handleSaveShow}
@@ -216,14 +220,14 @@ function App() {
   if (addingShow) {
     if (!selectedShowType) {
       return (
-        <ShowTypeSelector 
+        <ShowTypeSelector
           onSelectType={selectShowType}
           onCancel={cancelAddShow}
         />
       );
     } else {
       return (
-        <NewShowEditor 
+        <NewShowEditor
           showType={selectedShowType}
           onCancel={cancelAddShow}
           onSave={handleSaveNewShow}
@@ -237,7 +241,9 @@ function App() {
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="max-w-4xl mx-auto px-4">
         <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">Rapid Riter Shows</h1>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Rapid Riter Shows
+          </h1>
           <button
             onClick={startAddingShow}
             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors cursor-pointer"
@@ -245,14 +251,14 @@ function App() {
             Add Show
           </button>
         </div>
-        
+
         {shows.length === 0 ? (
           <div className="text-center py-12">
             <p className="text-gray-500 text-lg">No shows found</p>
           </div>
         ) : (
           <div className="space-y-4">
-            {shows.map(show => (
+            {shows.map((show) => (
               <ShowCard
                 key={show.id}
                 show={show}
@@ -265,14 +271,13 @@ function App() {
           </div>
         )}
       </div>
-      
-      
+
       <footer className="mt-16 pb-8">
         <div className="max-w-4xl mx-auto px-4 text-center">
           <p className="text-md text-gray-400">
-            <a 
-              href="https://github.com/gregsadetsky/rapidriteros" 
-              target="_blank" 
+            <a
+              href="https://github.com/gregsadetsky/rapidriteros"
+              target="_blank"
               rel="noopener noreferrer"
               className="hover:text-gray-600 transition-colors underline"
             >

--- a/web/core/frontend/src/App.tsx
+++ b/web/core/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import Cookies from "js-cookie";
 import { useEffect, useState } from "react";
+import { useNavigate, Routes, Route } from "react-router";
 import "./App.css";
 import { NewShowEditor } from "./components/NewShowEditor";
 import { ShowCard } from "./components/ShowCard";
@@ -29,6 +30,8 @@ function App() {
   const [editingShow, setEditingShow] = useState<ShowDetail | null>(null);
   const [addingShow, setAddingShow] = useState(false);
   const [selectedShowType, setSelectedShowType] = useState<string | null>(null);
+
+  let navigate = useNavigate();
 
   const fetchShows = () => {
     fetch("/api/shows")
@@ -147,6 +150,7 @@ function App() {
       const data = await response.json();
       if (data.success) {
         setEditingShow(data.show);
+        navigate("/edit-show");
       }
     } catch (err) {
       console.error("Error fetching show details:", err);
@@ -154,21 +158,20 @@ function App() {
   };
 
   const closeEditor = () => {
-    setEditingShow(null);
+    navigate("/");
   };
 
   const startAddingShow = () => {
-    setAddingShow(true);
-    setSelectedShowType(null);
+    navigate("/select-type");
   };
 
   const selectShowType = (showType: string) => {
     setSelectedShowType(showType);
+    navigate("/new-show");
   };
 
   const cancelAddShow = () => {
-    setAddingShow(false);
-    setSelectedShowType(null);
+    navigate("/", { replace: true });
   };
 
   const handleSaveNewShow = () => {
@@ -177,7 +180,7 @@ function App() {
   };
 
   const backToTypeSelection = () => {
-    setSelectedShowType(null);
+    navigate("/select-type", { replace: true });
   };
 
   const handleSaveShow = () => {
@@ -207,88 +210,98 @@ function App() {
       </div>
     );
 
-  if (editingShow) {
-    return (
-      <ShowEditor
-        show={editingShow}
-        onClose={closeEditor}
-        onSave={handleSaveShow}
-      />
-    );
-  }
-
-  if (addingShow) {
-    if (!selectedShowType) {
-      return (
-        <ShowTypeSelector
-          onSelectType={selectShowType}
-          onCancel={cancelAddShow}
-        />
-      );
-    } else {
-      return (
-        <NewShowEditor
-          showType={selectedShowType}
-          onCancel={cancelAddShow}
-          onSave={handleSaveNewShow}
-          onBackToTypeSelection={backToTypeSelection}
-        />
-      );
-    }
-  }
-
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-4xl mx-auto px-4">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">
-            Rapid Riter Shows
-          </h1>
-          <button
-            onClick={startAddingShow}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors cursor-pointer"
-          >
-            Add Show
-          </button>
-        </div>
+    <Routes>
+      <Route
+        index
+        element={
+          <>
+            <div className="min-h-screen bg-gray-50 py-8">
+              <div className="max-w-4xl mx-auto px-4">
+                <div className="flex justify-between items-center mb-8">
+                  <h1 className="text-3xl font-bold text-gray-900">
+                    Rapid Riter Shows
+                  </h1>
+                  <button
+                    onClick={startAddingShow}
+                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors cursor-pointer"
+                  >
+                    Add Show
+                  </button>
+                </div>
 
-        {shows.length === 0 ? (
-          <div className="text-center py-12">
-            <p className="text-gray-500 text-lg">No shows found</p>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            {shows.map((show) => (
-              <ShowCard
-                key={show.id}
-                show={show}
-                onEdit={editShow}
-                onToggleDisabled={setShowDisabled}
-                onDelete={deleteShow}
-                onShowImmediately={showImmediately}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+                {shows.length === 0 ? (
+                  <div className="text-center py-12">
+                    <p className="text-gray-500 text-lg">No shows found</p>
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {shows.map((show) => (
+                      <ShowCard
+                        key={show.id}
+                        show={show}
+                        onEdit={editShow}
+                        onToggleDisabled={setShowDisabled}
+                        onDelete={deleteShow}
+                        onShowImmediately={showImmediately}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
 
-      <footer className="mt-16 pb-8">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <p className="text-md text-gray-400">
-            <a
-              href="https://github.com/gregsadetsky/rapidriteros"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-gray-600 transition-colors underline"
-            >
-              GitHub
-            </a>
-            {" • "}
-            Contact Greg Sadetsky F2'23 for any questions
-          </p>
-        </div>
-      </footer>
-    </div>
+              <footer className="mt-16 pb-8">
+                <div className="max-w-4xl mx-auto px-4 text-center">
+                  <p className="text-md text-gray-400">
+                    <a
+                      href="https://github.com/gregsadetsky/rapidriteros"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-gray-600 transition-colors underline"
+                    >
+                      GitHub
+                    </a>
+                    {" • "}
+                    Contact Greg Sadetsky F2'23 for any questions
+                  </p>
+                </div>
+              </footer>
+            </div>
+          </>
+        }
+      />
+      <Route
+        path="edit-show"
+        element={
+          <ShowEditor
+            show={editingShow}
+            onClose={closeEditor}
+            onSave={handleSaveShow}
+          />
+        }
+      />
+
+      <Route
+        path="select-type"
+        element={
+          <ShowTypeSelector
+            onSelectType={selectShowType}
+            onCancel={cancelAddShow}
+          />
+        }
+      />
+      <Route
+        path="new-show"
+        element={
+          <NewShowEditor
+            showType={selectedShowType}
+            onCancel={cancelAddShow}
+            onSave={handleSaveNewShow}
+            onBackToTypeSelection={backToTypeSelection}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/web/core/frontend/src/main.tsx
+++ b/web/core/frontend/src/main.tsx
@@ -3,9 +3,14 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import "vite/modulepreload-polyfill";
+import { HashRouter } from "react-router";
+
+window.location.hash = "";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <HashRouter>
+      <App />
+    </HashRouter>
   </StrictMode>,
 );

--- a/web/core/frontend/src/main.tsx
+++ b/web/core/frontend/src/main.tsx
@@ -1,11 +1,11 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
-import 'vite/modulepreload-polyfill';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
+import "vite/modulepreload-polyfill";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);


### PR DESCRIPTION
this change introduces a `HashRouter` (https://reactrouter.com/api/declarative-routers/HashRouter) that does single-page routing for the frontend; the goal of this change was primarily to make the browser back button work

i tested locally and it seems to work? I had to do some hacky workarounds like disabling auth everywhere to make it work locally

i also realized i had run prettier on the files unintentionally, so I split that out to its own commit